### PR TITLE
feat: add ECS service

### DIFF
--- a/link2aws.js
+++ b/link2aws.js
@@ -419,7 +419,7 @@ class ARN {
             "ecs": { // Amazon Elastic Container Service
                 "cluster": () => `https://${this.region}.${this.console}/ecs/home?region=${this.region}#/clusters/${this.resource}`,
                 "container-instance": null,
-                "service": null,
+                "service": () => `https://${this.region}.${this.console}/ecs/home?region=${this.region}#/clusters/${this.pathAllButLast}/services/${this.pathLast}/details`,
                 "task": () => `https://${this.region}.${this.console}/ecs/home?region=${this.region}#/clusters/${this.pathAllButLast}/tasks/${this.pathLast}`,
                 "task-definition": null,
                 "task-set": null,

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -13,6 +13,7 @@
 
     "arn:aws:ecs:us-east-1:123456789012:cluster/mycluster": "https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/mycluster",
     "arn:aws:ecs:us-east-1:123456789012:task/mycluster/581a40b2431e6c9c23834b0760666c36": "https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/mycluster/tasks/581a40b2431e6c9c23834b0760666c36",
+    "arn:aws:ecs:us-east-1:123456789012:service/mycluster/myservice": "https://us-east-1.console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/mycluster/services/myservice/details",
 
     "arn:aws:dynamodb:us-east-1:123456789012:table/test": "https://us-east-1.console.aws.amazon.com/dynamodbv2/home?region=us-east-1#table?name=test",
 


### PR DESCRIPTION
Adds ECS service.

Note that there is a "New ECS experience" on AWS which has a new url pattern, this follows the old pattern so it matches the other types on the ECS model. Currently all the old urls do redirect to the new pattern so not an issue, but just thought i'd raise it.