### PR TITLE
EC2 implementations, additions and fix

### DIFF
--- a/link2aws.js
+++ b/link2aws.js
@@ -438,7 +438,7 @@ class ARN {
                 "internet-gateway": null,
                 "natgateway": () => `https://${this.region}.${this.console}/vpcconsole/home?region=${this.region}#NatGatewayDetails:natGatewayId=${this.resource}`,
                 "key-pair": null,
-                "launch-template": null,
+                "launch-template": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#LaunchTemplateDetails:launchTemplateId=${this.resource}`,
                 "local-gateway": null,
                 "local-gateway-route-table": null,
                 "local-gateway-route-table-virtual-interface-group-association": null,

--- a/link2aws.js
+++ b/link2aws.js
@@ -436,6 +436,7 @@ class ARN {
                 "image": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#ImageDetails:imageId=${this.resource}`,
                 "instance": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#InstanceDetails:instanceId=${this.resource}`,
                 "internet-gateway": null,
+                "natgateway": () => `https://${this.region}.${this.console}/vpcconsole/home?region=${this.region}#NatGatewayDetails:natGatewayId=${this.resource}`,
                 "key-pair": null,
                 "launch-template": null,
                 "local-gateway": null,

--- a/link2aws.js
+++ b/link2aws.js
@@ -434,7 +434,7 @@ class ARN {
                 "elastic-gpu": null,
                 "fpga-image": null,
                 "image": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#ImageDetails:imageId=${this.resource}`,
-                "instance": () => `https://${this.region}.${this.console}/ec2/v2/home`,
+                "instance": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#InstanceDetails:instanceId=${this.resource}`,
                 "internet-gateway": null,
                 "key-pair": null,
                 "launch-template": null,

--- a/link2aws.js
+++ b/link2aws.js
@@ -463,7 +463,7 @@ class ARN {
                 "transit-gateway-route-table": null,
                 "volume": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#VolumeDetails:volumeId=${this.resource}`,
                 "vpc": () => `https://${this.region}.${this.console}/vpc/home?region=${this.region}#VpcDetails:VpcId=${this.resource}`,
-                "vpc-endpoint": null,
+                "vpc-endpoint": () => `https://${this.region}.${this.console}/vpcconsole/home?region=${this.region}#EndpointDetails:vpcEndpointId=${this.resource}`,
                 "vpc-endpoint-service": null,
                 "vpc-flow-log": null,
                 "vpc-peering-connection": null,

--- a/link2aws.js
+++ b/link2aws.js
@@ -461,7 +461,7 @@ class ARN {
                 "transit-gateway-attachment": null,
                 "transit-gateway-multicast-domain": null,
                 "transit-gateway-route-table": null,
-                "volume": null,
+                "volume": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#VolumeDetails:volumeId=${this.resource}`,
                 "vpc": () => `https://${this.region}.${this.console}/vpc/home?region=${this.region}#VpcDetails:VpcId=${this.resource}`,
                 "vpc-endpoint": null,
                 "vpc-endpoint-service": null,

--- a/link2aws.js
+++ b/link2aws.js
@@ -509,7 +509,7 @@ class ARN {
             "elasticloadbalancing": { // AWS WAF V2
                 "listener": null,
                 "listener-rule": null,
-                "loadbalancer": null,
+                "loadbalancer": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#LoadBalancer:loadBalancerArn=${this.arn}`,
                 "targetgroup": null,
             },
             "elasticmapreduce": { // Amazon Elastic MapReduce

--- a/link2aws.js
+++ b/link2aws.js
@@ -450,7 +450,7 @@ class ARN {
                 "reserved-instances": null,
                 "route-table": null,
                 "security-group": () => `https://${this.region}.${this.console}/vpc/home?region=${this.region}#SecurityGroup:groupId=${this.resource}`,
-                "snapshot": null,
+                "snapshot": () => `https://${this.region}.${this.console}/ec2/home?region=${this.region}#SnapshotDetails:snapshotId=${this.resource}`,
                 "spot-instances-request": null,
                 "subnet": () => `https://${this.region}.${this.console}/vpc/home?region=${this.region}#SubnetDetails:subnetId=${this.resource}`,
                 "traffic-mirror-filter": null,

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -8,6 +8,7 @@
 
     "arn:aws:ec2:us-west-1:136693071363:image/ami-0851c4af3ebd71c35": "https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#ImageDetails:imageId=ami-0851c4af3ebd71c35",
     "arn:aws:ec2:us-east-1:123456789012:instance/1234": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceDetails:instanceId=1234",
+    "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-123456": "https://us-east-1.console.aws.amazon.com/vpcconsole/home?region=us-east-1#NatGatewayDetails:natGatewayId=nat-123456",
     "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-12345612312312312" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SubnetDetails:subnetId=subnet-12345612312312312",
     "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345123123123123": "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroup:groupId=sg-12345123123123123",
     "arn:aws:ec2:us-east-1:123456789012:snapshot/snap-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SnapshotDetails:snapshotId=snap-123456",

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -10,6 +10,7 @@
     "arn:aws:ec2:us-east-1:123456789012:instance/1234": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceDetails:instanceId=1234",
     "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-12345612312312312" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SubnetDetails:subnetId=subnet-12345612312312312",
     "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345123123123123": "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroup:groupId=sg-12345123123123123",
+    "arn:aws:ec2:us-east-1:123456789012:snapshot/snap-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SnapshotDetails:snapshotId=snap-123456",
     "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-5432109876" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#VpcDetails:VpcId=vpc-5432109876",
 
     "arn:aws:ecs:us-east-1:123456789012:cluster/mycluster": "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/mycluster?region=us-east-1",

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -7,7 +7,7 @@
     "arn:aws:acm:us-east-1:123456789012:certificate/1f6ee793-4064-4a10-9567-f03875640b35": "https://console.aws.amazon.com/acm/home?region=us-east-1#/?id=1f6ee793-4064-4a10-9567-f03875640b35",
 
     "arn:aws:ec2:us-west-1:136693071363:image/ami-0851c4af3ebd71c35": "https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#ImageDetails:imageId=ami-0851c4af3ebd71c35",
-    "arn:aws:ec2:us-east-1:123456789012:instance/1234": "https://us-east-1.console.aws.amazon.com/ec2/v2/home",
+    "arn:aws:ec2:us-east-1:123456789012:instance/1234": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceDetails:instanceId=1234",
     "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-12345612312312312" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SubnetDetails:subnetId=subnet-12345612312312312",
     "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345123123123123": "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroup:groupId=sg-12345123123123123",
     "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-5432109876" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#VpcDetails:VpcId=vpc-5432109876",

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -9,6 +9,7 @@
     "arn:aws:ec2:us-west-1:136693071363:image/ami-0851c4af3ebd71c35": "https://us-west-1.console.aws.amazon.com/ec2/home?region=us-west-1#ImageDetails:imageId=ami-0851c4af3ebd71c35",
     "arn:aws:ec2:us-east-1:123456789012:instance/1234": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceDetails:instanceId=1234",
     "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-123456": "https://us-east-1.console.aws.amazon.com/vpcconsole/home?region=us-east-1#NatGatewayDetails:natGatewayId=nat-123456",
+    "arn:aws:ec2:us-east-1:123456789012:launch-template/lt-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LaunchTemplateDetails:launchTemplateId=lt-123456",
     "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-12345612312312312" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SubnetDetails:subnetId=subnet-12345612312312312",
     "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345123123123123": "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroup:groupId=sg-12345123123123123",
     "arn:aws:ec2:us-east-1:123456789012:snapshot/snap-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SnapshotDetails:snapshotId=snap-123456",

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -13,6 +13,7 @@
     "arn:aws:ec2:us-east-1:123456789012:snapshot/snap-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SnapshotDetails:snapshotId=snap-123456",
     "arn:aws:ec2:us-east-1:123456789012:volume/vol-123456" : "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#VolumeDetails:volumeId=vol-123456",
     "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-5432109876" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#VpcDetails:VpcId=vpc-5432109876",
+    "arn:aws:ec2:us-east-1:123456789012:vpc-endpoint/vpce-123456": "https://us-east-1.console.aws.amazon.com/vpcconsole/home?region=us-east-1#EndpointDetails:vpcEndpointId=vpce-123456",
 
     "arn:aws:ecs:us-east-1:123456789012:cluster/mycluster": "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/mycluster?region=us-east-1",
     "arn:aws:ecs:us-east-1:123456789012:task/mycluster/581a40b2431e6c9c23834b0760666c36": "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/mycluster/tasks/581a40b2431e6c9c23834b0760666c36?region=us-east-1",

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -76,6 +76,8 @@
     "arn:aws:eks:us-east-1:123456789012:cluster/test-cluster": "https://console.aws.amazon.com/eks/home?region=us-east-1#/clusters/test-cluster",
     "arn:aws:eks:us-east-1:123456789012:nodegroup/test-cluster/test-workers/a2c51527-da50-031f-1130-c5d5d77be06c": "https://console.aws.amazon.com/eks/home?region=us-east-1#/clusters/test-cluster/nodegroups/test-workers",
 
+    "arn:aws:elasticloadbalancing:us-east-1:1234:loadbalancer/net/k8s-devops-ingressn-5a6b7c/8d9e0f": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#LoadBalancer:loadBalancerArn=arn:aws:elasticloadbalancing:us-east-1:1234:loadbalancer/net/k8s-devops-ingressn-5a6b7c/8d9e0f",
+
     "arn:aws:backup:us-east-1:123456789012:backup-vault:backups-primary": "https://console.aws.amazon.com/backup/home?region=us-east-1#/backupvaults/details/backups-primary",
 
     "arn:aws:firehose:us-east-1:123456789012:deliverystream/test-stream": "https://console.aws.amazon.com/firehose/home?region=us-east-1#/details/test-stream/monitoring"

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -11,6 +11,7 @@
     "arn:aws:ec2:us-east-1:123456789012:subnet/subnet-12345612312312312" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SubnetDetails:subnetId=subnet-12345612312312312",
     "arn:aws:ec2:us-east-1:123456789012:security-group/sg-12345123123123123": "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#SecurityGroup:groupId=sg-12345123123123123",
     "arn:aws:ec2:us-east-1:123456789012:snapshot/snap-123456": "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#SnapshotDetails:snapshotId=snap-123456",
+    "arn:aws:ec2:us-east-1:123456789012:volume/vol-123456" : "https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#VolumeDetails:volumeId=vol-123456",
     "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-5432109876" : "https://us-east-1.console.aws.amazon.com/vpc/home?region=us-east-1#VpcDetails:VpcId=vpc-5432109876",
 
     "arn:aws:ecs:us-east-1:123456789012:cluster/mycluster": "https://us-east-1.console.aws.amazon.com/ecs/v2/clusters/mycluster?region=us-east-1",


### PR DESCRIPTION
## Fixes
- EC2 Instance:
  Current implementation create a link to the list of instances.
  An enhanced experience is to receive the link of the instance itself.
  Example of AWS link of EC2 instance: `https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#InstanceDetails:instanceId=i-1234`

## Implementations
- EC2 Snapshot
- EC2 volume
- Elastic Load Balancer
- EC2 vpc-endpoint
- EC2 launch-template

## Additions
- EC2: nat gateways