### PR TITLE
Add secretsmanager

### DIFF
--- a/link2aws.js
+++ b/link2aws.js
@@ -979,14 +979,11 @@ class ARN {
             },
             "secretsmanager": { // AWS Secrets Manager
                 "secret": () => {
-                    if (this.resource.indexOf("-") === -1) {
-                        // all the secrets I've seen have a "-" delimited suffix
-                        // in the ARN that isn't part of the secret name. For
-                        // now just throwing if the suffix is missing, please
-                        // update if needed.
-                        throw Error(`Secret ARN for ${this.resource} missing suffix`);
+                    const arnSuffix = /-\w{6}$/;
+                    if (!arnSuffix.test(this.resource)) {
+                        throw Error(`Secret ARN for "${this.resource}" appears invalid, should end with ${arnSuffix}`);
                     }
-                    const name = this.resource.split('-').slice(0, -1).join('-');
+                    const name = this.resource.replace(arnSuffix, "");
                     return `https://${this.region}.${this.console}/${this.service}/${this.resource_type}?name=${name}`;
                 },
             },

--- a/link2aws.js
+++ b/link2aws.js
@@ -978,7 +978,17 @@ class ARN {
                 "domain": null,
             },
             "secretsmanager": { // AWS Secrets Manager
-                "secret": null,
+                "secret": () => {
+                    if (this.resource.indexOf("-") === -1) {
+                        // all the secrets I've seen have a "-" delimited suffix
+                        // in the ARN that isn't part of the secret name. For
+                        // now just throwing if the suffix is missing, please
+                        // update if needed.
+                        throw Error(`Secret ARN for ${this.resource} missing suffix`);
+                    }
+                    const name = this.resource.split('-').slice(0, -1).join('-');
+                    return `https://${this.region}.${this.console}/${this.service}/${this.resource_type}?name=${name}`;
+                },
             },
             "securityhub": { // AWS Security Hub
                 "hub": null,

--- a/testcases/aws-negative.json
+++ b/testcases/aws-negative.json
@@ -38,5 +38,6 @@
     "arn:aws:ec2:us-ea st-1:123456789012:instance/asdf",
     "arn:aws:ec2:us-ea*st-1:123456789012:instance/asdf",
     "arn:aws:ec2:us-ea#st-1:123456789012:instance/asdf",
-    "arn:aws:ec2:us-ea\\st-1:123456789012:instance/asdf"
+    "arn:aws:ec2:us-ea\\st-1:123456789012:instance/asdf",
+    "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret9A3F29"
 ]

--- a/testcases/aws-negative.json
+++ b/testcases/aws-negative.json
@@ -39,5 +39,5 @@
     "arn:aws:ec2:us-ea*st-1:123456789012:instance/asdf",
     "arn:aws:ec2:us-ea#st-1:123456789012:instance/asdf",
     "arn:aws:ec2:us-ea\\st-1:123456789012:instance/asdf",
-    "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret9A3F29"
+    "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret9A3F29-adf"
 ]

--- a/testcases/aws.json
+++ b/testcases/aws.json
@@ -86,6 +86,7 @@
     "arn:aws:firehose:us-east-1:123456789012:deliverystream/test-stream": "https://console.aws.amazon.com/firehose/home?region=us-east-1#/details/test-stream/monitoring",
 
     "arn:aws:codeconnections:us-west-2:384862141196:connection/f8234ecc-8990-4e63-b25a-ec36764b7701": "https://us-west-2.console.aws.amazon.com/codesuite/settings/384862141196/us-west-2/codeconnections/connections/f8234ecc-8990-4e63-b25a-ec36764b7701",
-    "arn:aws:codestar-connections:us-west-2:384862141196:connection/f8234ecc-8990-4e63-b25a-ec36764b7701": "https://us-west-2.console.aws.amazon.com/codesuite/settings/384862141196/us-west-2/codestar-connections/connections/f8234ecc-8990-4e63-b25a-ec36764b7701"
+    "arn:aws:codestar-connections:us-west-2:384862141196:connection/f8234ecc-8990-4e63-b25a-ec36764b7701": "https://us-west-2.console.aws.amazon.com/codesuite/settings/384862141196/us-west-2/codestar-connections/connections/f8234ecc-8990-4e63-b25a-ec36764b7701",
 
+    "arn:aws:secretsmanager:us-west-2:123456789012:secret:MySecret9A3F29-vdHtS43BP1i1-knwb3S": "https://us-west-2.console.aws.amazon.com/secretsmanager/secret?name=MySecret9A3F29-vdHtS43BP1i1"
 }


### PR DESCRIPTION
The resource segment of the ARN has an extra trailing "-abc123" piece that isn't part of the secret name and can't be included in the console URL. It always appears to be a `-` followed by six alphanumeric chars.

Example:
Secret ARN: `arn:<stuff...>:MySecret9A3F29-vdHtS43BP1i1-knwb3S`
Secret Name: `MySecret9A3F29-vdHtS43BP1i1`

Looks like this is specifically documented, so throwing an error if the suffix is missing.

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-secretsmanager-secret.html#cfn-secretsmanager-secret-name